### PR TITLE
Fix URL to MJCF models (JVRC-1/Aliengo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Quadruped robots have four legs.
 | Name | Maker | Formats | License | Joints | Mass (kg) |
 |------|-------|---------|---------|--------|-----------|
 | A1 | UNITREE Robotics | [URDF](https://github.com/unitreerobotics/unitree_ros/tree/master/robots/a1_description) | MPL-2.0 | 12 | 19 |
-| Aliengo | UNITREE Robotics | [MJCF](https://github.com/rohanpsingh/aliengo_mj_description), [URDF](https://github.com/unitreerobotics/unitree_ros/tree/master/robots/aliengo_description) | MPL-2.0 | 12 | 21 |
+| Aliengo | UNITREE Robotics | [MJCF](https://github.com/unitreerobotics/unitree_mujoco/tree/main/data/aliengo/xml), [URDF](https://github.com/unitreerobotics/unitree_ros/tree/master/robots/aliengo_description) | MPL-2.0 | 12 | 21 |
 | ANYmal B | ANYbotics | [URDF](https://github.com/ANYbotics/anymal_b_simple_description) | BSD-3-Clause | 12 | 30 |
 | ANYmal C | ANYbotics | [URDF](https://github.com/ANYbotics/anymal_c_simple_description) | BSD-3-Clause | 12 | 52 |
 | HyQ | IIT | [URDF](https://github.com/Gepetto/example-robot-data/tree/master/robots/hyq_description) | Apache-2.0 | 12 | 87 |

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Humanoids have a torso, two legs and two arms.
 |------|-------|---------|---------|--------|-----------|
 | Atlas | Boston Dynamics | [URDF](https://github.com/RobotLocomotion/drake/tree/master/examples/atlas) | BSD-3-Clause | 30 | 175 |
 | iCub | IIT | [URDF](https://github.com/Gepetto/example-robot-data/tree/master/robots/icub_description) | CC-BY-SA-4.0 | 32 | 28 |
-| JVRC-1 | AIST | [MJCF](https://github.com/rohanpsingh/jvrc_mj_description/), [URDF](https://github.com/stephane-caron/jvrc_description) | BSD-2-Clause | 44 | 62 |
+| JVRC-1 | AIST | [MJCF](https://github.com/isri-aist/jvrc_mj_description/), [URDF](https://github.com/stephane-caron/jvrc_description) | BSD-2-Clause | 44 | 62 |
 | Romeo | Aldebaran Robotics | [URDF](https://github.com/ros-aldebaran/romeo_robot/tree/master/romeo_description) | BSD-3-Clause | 37 | 41 |
 | TALOS | PAL Robotics | [URDF](https://github.com/stack-of-tasks/talos-data) | LGPL-3.0 | 44 | 109 |
 | WALK-MAN | IIT | [Xacro](https://github.com/ADVRHumanoids/iit-walkman-ros-pkg/tree/master/walkman_urdf) | BSD-3-Clause | 30 | 94 |


### PR DESCRIPTION
I think it is better to use these remotes instead as they are more likely to be up-to-date and free of bugs.