### PR TITLE
Update Spot's Xacro Description with More Official and Accurate Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ A curated list of awesome robot descriptions in URDF, Xacro or MJCF formats.
 | Pupper v3 | Gabrael Levine | [URDF](https://github.com/G-Levine/pupper_v3_description) | MIT | ✔️ | ✔️ | ✔️ |
 | Solo | ODRI | [URDF](https://github.com/Gepetto/example-robot-data/tree/master/robots/solo_description) | BSD-3-Clause | ✔️ | ✔️ | ✔️ |
 | Spot | Boston Dynamics | [MJCF](https://github.com/google-deepmind/mujoco_menagerie/tree/main/boston_dynamics_spot) | BSD-3-Clause | ✔️ | ✔️ | ✔️ |
-| Spot | Boston Dynamics | [Xacro](https://github.com/clearpathrobotics/spot_ros/tree/master/spot_description) | ✖️ | ✔️ | ✖️ | ✔️ |
+| Spot | Boston Dynamics | [Xacro](https://github.com/bdaiinstitute/spot_description) | MIT | ✔️ | ✔️ | ✔️ |
 
 ### Wheeled
 


### PR DESCRIPTION
This PR updates the Spot Xacro description to reference a more official and accurate source. The new link points to the Robotics and AI Institute’s official repository (formerly the Boston Dynamics AI Institute), which is licensed under MIT and actively maintained. Unlike the previously referenced repository, this one includes inertia parameters, making it a more complete and up-to-date resource. I believe it is more appropriate to direct users to this repository instead.

I should also mention that this repository served as the basis for the MJCF description used in Mujoco, as mentioned in the [Mujoco Menagerie repository](https://github.com/google-deepmind/mujoco_menagerie/tree/main/boston_dynamics_spot).